### PR TITLE
installation instructions: corrects path to dist folder.

### DIFF
--- a/config-ohif/README.md
+++ b/config-ohif/README.md
@@ -26,7 +26,7 @@ QUICK_BUILD=true PUBLIC_URL=/mod/dicomviewer/viewer-ohif/ yarn run build
 
 It is possible to modify this url according to the directory of your moodle site.
 
-5) Copy the files present in:  Viewers/platform/viewer/dist/*  in the plugin folder named viewer-ohif/
+5) Copy the files present in:  Viewers/platform/app/dist/*  in the plugin folder named viewer-ohif/
 
 6) Move the configuration files found at the root of the plugin (config-ohif/) in the distribution of ohif (viewer-ohif/)
 


### PR DESCRIPTION
the `dist` directory is now located within the `app` directory, `viewer` doesn't exist anymore in that directory structure.

for reference, please see the current [OHIF build instructions](https://docs.ohif.org/deployment/build-for-production).
